### PR TITLE
Update CLN to 26.06.1 and LND to 0.21.0-beta

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     hostname: clightning-1
     depends_on:
       - bitcoind
-    image: boltz/c-lightning:24.08
+    image: boltz/c-lightning:26.06.1
     entrypoint: "sh -c 'sleep 15 && lightningd --large-channels --network regtest --grpc-port 9738 --bind-addr=0.0.0.0:9735 --bitcoin-rpcconnect=bitcoind --bitcoin-rpcport=18443 --bitcoin-rpcuser=cashu --bitcoin-rpcpassword=cashu --clnrest-port=3010 --clnrest-host=0.0.0.0'"
     expose:
       - 9735
@@ -25,7 +25,7 @@ services:
     hostname: clightning-2
     depends_on:
       - bitcoind
-    image: boltz/c-lightning:24.08
+    image: boltz/c-lightning:26.06.1
     entrypoint: "sh -c 'sleep 15 && lightningd --large-channels --network regtest --grpc-port 9738 --bind-addr=0.0.0.0:9735 --bitcoin-rpcconnect=bitcoind --bitcoin-rpcport=18443 --bitcoin-rpcuser=cashu --bitcoin-rpcpassword=cashu --clnrest-port=3010 --clnrest-host=0.0.0.0'"
     ports:
       - 3010:3010
@@ -53,7 +53,7 @@ services:
     hostname: clightning-3
     depends_on:
       - bitcoind
-    image: boltz/c-lightning:24.08
+    image: boltz/c-lightning:26.06.1
     entrypoint: "sh -c 'sleep 15 && lightningd --large-channels --network regtest --grpc-port 9738 --bind-addr=0.0.0.0:9735 --bitcoin-rpcconnect=bitcoind --bitcoin-rpcport=18443 --bitcoin-rpcuser=cashu --bitcoin-rpcpassword=cashu  --clnrest-port=3010 --clnrest-host=0.0.0.0'"
     expose:
       - 9735
@@ -64,7 +64,7 @@ services:
     hostname: lnd-1
     depends_on:
       - bitcoind
-    image: boltz/lnd:0.18.1-beta
+    image: boltz/lnd:0.21.0-beta
     restart: on-failure
     entrypoint: "sh -c 'sleep 20; lnd --listen=lnd-1:9735 --rpclisten=lnd-1:10009 --restlisten=lnd-1:8081 --bitcoin.active --bitcoin.regtest --bitcoin.node=bitcoind --bitcoind.rpchost=bitcoind --bitcoind.zmqpubrawtx=bitcoind:29000 --bitcoind.zmqpubrawblock=bitcoind:29001 --bitcoind.rpcuser=cashu --bitcoind.rpcpass=cashu --noseedbackup --protocol.wumbo-channels'"
     expose:
@@ -78,7 +78,7 @@ services:
     hostname: lnd-2
     depends_on:
       - bitcoind
-    image: boltz/lnd:0.18.1-beta
+    image: boltz/lnd:0.21.0-beta
     restart: on-failure
     entrypoint: "sh -c 'sleep 20; lnd --listen=lnd-2:9735 --rpclisten=lnd-2:10009 --restlisten=lnd-2:8081 --bitcoin.active --bitcoin.regtest --bitcoin.node=bitcoind --bitcoind.rpchost=bitcoind --bitcoind.zmqpubrawtx=bitcoind:29000 --bitcoind.zmqpubrawblock=bitcoind:29001 --bitcoind.rpcuser=cashu --bitcoind.rpcpass=cashu --noseedbackup --protocol.wumbo-channels'"
     expose:
@@ -92,7 +92,7 @@ services:
     hostname: lnd-3
     depends_on:
       - bitcoind
-    image: boltz/lnd:0.18.1-beta
+    image: boltz/lnd:0.21.0-beta
     restart: on-failure
     entrypoint: "sh -c 'sleep 20; lnd --listen=lnd-3:9735 --rpclisten=lnd-3:10009 --restlisten=lnd-3:8081 --bitcoin.active --bitcoin.regtest --bitcoin.node=bitcoind --bitcoind.rpchost=bitcoind --bitcoind.zmqpubrawtx=bitcoind:29000 --bitcoind.zmqpubrawblock=bitcoind:29001 --bitcoind.rpcuser=cashu --bitcoind.rpcpass=cashu --noseedbackup --protocol.wumbo-channels'"
     ports:

--- a/docker-scripts.sh
+++ b/docker-scripts.sh
@@ -74,9 +74,9 @@ cashu-regtest-start-log(){
 cashu-regtest-stop(){
   docker compose down --volumes
   # clean up lightning node data
-  sudo rm -rf ./data/clightning-1 ./data/clightning-2 ./data/clightning-3 ./data/lnd-1  ./data/lnd-2 ./data/lnd-3 ./data/boltz/boltz.db
+  docker run --rm -v "$(pwd)/data:/data" alpine rm -rf /data/clightning-1 /data/clightning-2 /data/clightning-3 /data/lnd-1 /data/lnd-2 /data/lnd-3 /data/boltz/boltz.db
   # recreate lightning node data folders preventing permission errors
-  mkdir ./data/clightning-1 ./data/clightning-2 ./data/clightning-3 ./data/lnd-1 ./data/lnd-2 ./data/lnd-3
+  mkdir -p ./data/clightning-1 ./data/clightning-2 ./data/clightning-3 ./data/lnd-1 ./data/lnd-2 ./data/lnd-3
 }
 
 cashu-regtest-restart(){


### PR DESCRIPTION
This PR updates the CLN image to the latest stable version (26.06.1) and LND to the latest stable version (0.21.0-beta). It also updates the volume cleanup script in docker-scripts.sh to use a docker alpine container instead of sudo rm -rf, which resolves permission errors in non-interactive environments and simplifies continuous integration runs.