### PR TITLE
update lnbits image to v1.5.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,9 +112,9 @@ services:
     image: lnbits/lnbits:v1.5.4
     restart: on-failure
     user: "0:0"
-    entrypoint: "sh -c 'sleep 30; /app/.venv/bin/lnbits --port 5001 --host 0.0.0.0'"
+    entrypoint: "sh -c 'sleep 30; /app/.venv/bin/lnbits'"
     environment:
-      HOST: lnbits
+      HOST: 0.0.0.0
       PORT: 5001
       DEBUG: true
       LNBITS_BACKEND_WALLET_CLASS: "LndRestWallet"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,10 +109,10 @@ services:
     hostname: lnbits
     depends_on:
       - lnd-3
-    image: lnbitsdocker/lnbits-legend
+    image: lnbits/lnbits:v1.5.4
     restart: on-failure
     user: "0:0"
-    entrypoint: "sh -c 'sleep 30; poetry run lnbits'"
+    entrypoint: "sh -c 'sleep 30; /app/.venv/bin/lnbits --port 5001 --host 0.0.0.0'"
     environment:
       HOST: lnbits
       PORT: 5001

--- a/start.sh
+++ b/start.sh
@@ -56,7 +56,7 @@ for i in 1 2 3; do
   run "cln-$i channel[0].our_amount_msat" $(($balance_size * 1000)) $(lightning-cli-sim $i listfunds | jq -r ".channels[0].our_amount_msat" | sed 's/msat//g')
 done
 
-run "lnbits service status" "200" $(curl -s -o /dev/null -w "%{http_code}" "http://localhost:5001/")
+run "lnbits service status" "200" $(curl -s -L -o /dev/null -w "%{http_code}" "http://localhost:5001/")
 
 # return non-zero exit code if a test fails
 if [[ "$failed" == "true" ]]; then

--- a/start.sh
+++ b/start.sh
@@ -73,4 +73,4 @@ else
 fi
 
 # # LNbits create a wallet
-docker exec cashu-lnbits-1 poetry run python tools/create_fake_admin.py
+docker exec cashu-lnbits-1 /app/.venv/bin/python tools/create_fake_admin.py


### PR DESCRIPTION
This PR updates the LNbits docker image to the latest stable version (v1.5.4) from the official lnbits/lnbits repository, updating the entrypoint and start scripts to use the virtualenv python interpreter.